### PR TITLE
fix potential strncpy overrun

### DIFF
--- a/source/libgbfs.c
+++ b/source/libgbfs.c
@@ -105,7 +105,7 @@ const void *gbfs_get_obj(const GBFS_FILE *file,
                          const char *name,
                          unsigned int *len)
 {
-  char key[24] = {0};
+  char key[25] = {0};
 
   const GBFS_ENTRY *dirbase = (const GBFS_ENTRY *)((const char *)file + file->dir_off);
   size_t n_entries = file->dir_nmemb;


### PR DESCRIPTION
When compiling, the following warning is issued:

```
libgbfs/source/libgbfs.c: In function 'gbfs_get_obj':
libgbfs/source/libgbfs.c:114:3: warning: 'strncpy' specified bound 24 equals destination size [-Wstringop-truncation]
  114 |   strncpy(key, name, 24);
      |   ^~~~~~~~~~~~~~~~~~~~~~
```

This is because strncpy wants to terminate a string that is 24 characters in length by writing NUL after the 24 characters it will copy. This is resolved by expanding the key buffer by one character.